### PR TITLE
Allow markdown syntax in event comments 

### DIFF
--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -1,6 +1,6 @@
 %article
   .userMarkdown
-    = comment.description
+    = markdown comment.description
   .postHourUser
     %span
       Posté il y a #{distance_of_time_in_words_to_now(comment.created_at)}


### PR DESCRIPTION
Le site propose l’utilisation de la syntaxe markdown dans les commentaires d'événements, mais n'était manifestement pas activée.
