### PR TITLE
Mise à jour de la section "Groupes locaux"

### DIFF
--- a/app/views/resources/index.html.haml
+++ b/app/views/resources/index.html.haml
@@ -212,20 +212,30 @@
                 \#rails-contrib
         %article
           %h2 Groupes locaux
-          De nombreuses villes en France se retrouvent pour partager autour de Rails et de son écosystème.
+          De nombreuses villes en France se retrouvent régulièrement pour partager autour de Rails et de son écosystème.
           %ul
             %li 
-              = link_to "Paris.rb", "http://meetup.rubyparis.org/"
+              = link_to "Bordeaux", "http://www.facebook.com/rubybdx"
+            %li 
+              = link_to "Lille", "https://groups.google.com/forum/#!forum/ruby-nord"
             %li
-              = link_to "Lyon.rb", "http://lyonrb.fr/"
-            %li 
-              = link_to "Montpellier.rb", "http://fr-fr.facebook.com/AperoRubyMontpellier"
-            %li 
-              = link_to "Lille.rb", "https://groups.google.com/forum/#!forum/ruby-nord"
-            %li 
-              = link_to "Bordeaux.rb", "http://www.facebook.com/rubybdx"
+              = link_to "Lyon", "http://lyonrb.fr/"
             %li
-              = link_to "Toulouse.rb", "http://toulouserb.org"
+              = link_to "Marseille", "http://www.pastisrb.org/"
+            %li 
+              = link_to "Montpellier", "http://fr-fr.facebook.com/AperoRubyMontpellier"
+            %li
+              = link_to "Orleans", "http://www.meetup.com/Orleans-rb/"
+            %li 
+              = link_to "Paris", "http://meetup.rubyparis.org/"
+            %li
+              = link_to "Rennes", "http://www.rennesonrails.com/"
+            %li
+              = link_to "Sophia-Antipolis", "http://rivierarb.fr/"
+            %li
+              = link_to "Strasbourg", "https://www.facebook.com/AperoRubyStrasbourg"
+            %li
+              = link_to "Toulouse", "http://toulouserb.org"
         %article
           %h2 News
           Restez informés des nouveautés autour de Ruby on Rails.


### PR DESCRIPTION
- Ajout des villes manquantes (source : http://www.ruby-lang.org/fr/community/user-groups/)
- Tri par ordre alphabétique
- Suppression de l'extension .rb après chaque ville car tous les groupes n'ont pas suivi cette convention.
