### PR TITLE
Updates .travis.yml to start redis-server + run tests against ruby 2.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
   - 1.9.2
+  - 2.1.3
+before_install:
+  - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc'
 before_script:
   - cp config/database.yml.sample config/database.yml
   - "export DISPLAY=:99.0"
@@ -9,3 +12,6 @@ before_script:
   - psql -c 'create database rails_france_test;' -U postgres
   - bundle exec rake db:test:load --trace
 script: "bundle exec rake test:travis"
+services:
+  - redis-server
+cache: bundler


### PR DESCRIPTION
- redis-server doesn't start automatically anymore on travis, this fixes the issue so we can see the build go green again :fireworks:
- runs tests against 2.1.3 to prepare for server migration.
