### PR TITLE
Adding Le Wagon and Le Wagon on Demand to the training section

### DIFF
--- a/app/views/resources/index.html.haml
+++ b/app/views/resources/index.html.haml
@@ -168,6 +168,8 @@
             %ul
               %li
                 = link_to "OnTheRailsAgain (FR)", "http://ontherailsagain.com"
+              %li
+                = link_to "Débuter avec Ruby on Rails sur Le Wagon On Demand", "https://ondemand.lewagon.org/tracks/debutez-avec-ruby-on-rails/go"
           %article
             %h2 Formations
             %ul
@@ -177,6 +179,8 @@
                 = link_to "Formation Tests avec Ruby on Rails par Human Coders", "http://www.humancoders.com/formations/tests-avec-ruby-on-rails"
               %li
                 = link_to "Formation Ruby par Human Coders", "http://www.humancoders.com/formations/ruby"
+              %li
+                = link_to "Formation Développement Web par Le Wagon", "https://www.lewagon.com/programme"
 
     #community
       %aside


### PR DESCRIPTION
Dear maintainers, here is a Pull Request to add two links to the [http://www.railsfrance.org/ressources#learn](http://www.railsfrance.org/ressources#learn) page. At Le Wagon we have 2 training program:
- A video track with Le Wagon on Demand
- A 9-week coding bootcamp for beginners

Please feel free to ask any question!

See you soon at Paris.rb,

Cheers.
